### PR TITLE
Patched API compatibility for the new IRI

### DIFF
--- a/iota-agent/src/main/java/org/iotacontrolcenter/iota/agent/http/AddIotaNeighbors.java
+++ b/iota-agent/src/main/java/org/iotacontrolcenter/iota/agent/http/AddIotaNeighbors.java
@@ -5,5 +5,6 @@ public class AddIotaNeighbors extends HttpPost {
     public AddIotaNeighbors(String url) {
         super("addIotaNeighbors", url);
         addHeader("Content-Type", "application/json");
+        addHeader("X-IOTA-API-Version", "1.4.1");
     }
 }

--- a/iota-agent/src/main/java/org/iotacontrolcenter/iota/agent/http/GetIotaNeighbors.java
+++ b/iota-agent/src/main/java/org/iotacontrolcenter/iota/agent/http/GetIotaNeighbors.java
@@ -6,6 +6,7 @@ public class GetIotaNeighbors extends HttpPost {
     public GetIotaNeighbors(String url) {
         super("getIotaNeighbors", url, "{\"command\": \"getNeighbors\"}");
         addHeader("Content-Type", "application/json");
+        addHeader("X-IOTA-API-Version", "1.4.1");
     }
 }
 

--- a/iota-agent/src/main/java/org/iotacontrolcenter/iota/agent/http/GetIotaNodeInfo.java
+++ b/iota-agent/src/main/java/org/iotacontrolcenter/iota/agent/http/GetIotaNodeInfo.java
@@ -6,5 +6,6 @@ public class GetIotaNodeInfo extends HttpPost {
     public GetIotaNodeInfo(String url) {
         super("getIotaNodeInfo", url, "{\"command\": \"getNodeInfo\"}");
         addHeader("Content-Type", "application/json");
+        addHeader("X-IOTA-API-Version", "1.4.1");
     }
 }

--- a/iota-agent/src/main/java/org/iotacontrolcenter/iota/agent/http/RemoveIotaNeighbors.java
+++ b/iota-agent/src/main/java/org/iotacontrolcenter/iota/agent/http/RemoveIotaNeighbors.java
@@ -5,5 +5,6 @@ public class RemoveIotaNeighbors extends HttpPost {
     public RemoveIotaNeighbors(String url) {
         super("removeIotaNeighbors", url);
         addHeader("Content-Type", "application/json");
+        addHeader("X-IOTA-API-Version", "1.4.1");
     }
 }


### PR DESCRIPTION
IRI version 1.4.1 now requires `IOTA-API-Version: 1.4.1` to be added to the API call.
