### PR TITLE
Iccr release prep

### DIFF
--- a/installer/property-files/src/main/resources/iccr.properties
+++ b/installer/property-files/src/main/resources/iccr.properties
@@ -43,7 +43,9 @@ iccrPortNumber=14266
 iotaDownloadLink=http://85.93.93.110/iri-1.1.2.3.jar
 
 iotaDir=/opt/iota
-iotaStartCmd=java -jar IRI.jar -p
+
+iotaStartCmd=java -jar IRI.jar --dns-resolution-false -p
+
 iotaPortNumber=14265
 
 # Time in minutes:

--- a/release-iccr.bash
+++ b/release-iccr.bash
@@ -1,27 +1,21 @@
 #!/bin/bash
 
 if [ -z "${1}" ]; then
-    echo "Pass version, user, and group on command line"
+    echo "Pass user, and group on command line"
     echo You are:
     id
     exit
 fi
 
 if [ -z "${2}" ]; then
-    echo "Pass version, user, and group on command line"
+    echo "Pass user, and group on command line"
     echo You are:
     id
     exit
 fi
 
-if [ -z "${3}" ]; then
-    echo "Pass version, user, and group on command line"
-    echo You are:
-    id
-    exit
-fi
 
-version=$1
+version=1.0.0
 user=$2
 group=$3
 dir=/opt

--- a/release-iccr.bash
+++ b/release-iccr.bash
@@ -58,7 +58,7 @@ fi
 ./deploy-iccr.bash
 
 if [ ! -d $dist ]; then
-    mkdir $dist
+    mkdir -p $dist
 fi
 
 #cp changelog.txt $dist/icc-${version}-changelog.txt


### PR DESCRIPTION
Have done the chores for `iccr` 1.0.0 release prep
- fixed mkdir option if projects dir doesn't exist in `/home/$user/`.
- have set --dns-resolutio-flase flag in iccr.properties.
- have hardcoded version `1.0.0` and removed passing version as the arguement.